### PR TITLE
fix requirements.txt for lexrank

### DIFF
--- a/vision-api/requirements.txt
+++ b/vision-api/requirements.txt
@@ -2,3 +2,8 @@ Django
 djangorestframework
 django-filter
 django-cors-headers
+
+numpy
+scipy
+spacy
+ginza


### PR DESCRIPTION
lexrankで使っているライブラリをrequirementsに追加し忘れていた 😢 