### PR TITLE
フレーズおよび記事をベクトル化する処理を実装した

### DIFF
--- a/vision-api/vision_app/webapi/lib/vectorizer.py
+++ b/vision-api/vision_app/webapi/lib/vectorizer.py
@@ -1,0 +1,55 @@
+import numpy as np
+import spacy
+
+
+class GinzaVectorizer:
+    def __init__(self):
+        self.parser = spacy.load('ja_ginza')
+
+    def encode_phrase(self, phrase):
+        """フレーズをベクトル化する，
+        フレーズベクトルはフレーズ内の単語の平均ベクトル．
+
+        Parameters
+        ----------
+        phrase : str
+            フレーズ
+
+        Returns
+        -------
+        numpy.ndarray
+            フレーズベクトル
+        """        
+        parsed_phrase = self.parser(phrase, disable=['dep', 'ent'])
+        
+        return parsed_phrase.vector
+
+    def calc_weighted_article_vector(self, phrase_vectors, phrase_scores, theta=0.8):
+        """TrendScoreで重み付けした記事ベクトルを計算する．
+
+        Parameters
+        ----------
+        phrases : dict[str, numpy.ndarray]
+            記事から抽出したキーフレーズのベクトル．
+            Key : キーフレーズ
+            Value : キーフレーズベクトル
+        scores : dict[str, float]
+            記事から抽出したキーフレーズのTrendScore．
+            Key : キーフレーズ
+            Value : TrendScore
+        theta : float, default 0.8
+            TrendScoreを考慮する度合い．
+            値域は [0, 1]
+
+        Returns
+        -------
+        numpy.ndarray
+            記事ベクトル
+        """ 
+
+        weighted_phrase_vectors = []
+        for keyphrase in phrase_vectors.keys():
+            weighted_phrase_vector = (theta * phrase_scores[keyphrase] + (1.0 - theta)) * phrase_vectors[keyphrase]
+            weighted_phrase_vectors.append(weighted_phrase_vector)
+
+        return np.array(weighted_phrase_vectors).mean(axis=0)


### PR DESCRIPTION
GiNZAを使用してフレーズおよび記事をベクトル化する処理を実装した．
vectorizer.pyにGinzaVectorizerクラスを実装している．

```python
from vectorizer import GinzaVectorizer

vectorizer = GinzaVectorizer()

# フレーズをベクトル化する
phrase_vector = vectorizer.encode_phrase('菅義偉総裁')

# 記事ベクトルを計算する
## vectors: 記事から抽出したキーフレーズのベクトル．
## scores: 記事から抽出したキーフレーズのTrendScore．
## theta: TrendScoreを考慮する度合い．
article_vector = vectorizer.calc_weighted_article_vector(vectors, scores, theta=0.8)
```